### PR TITLE
Fix peoplesopen.net link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PeoplesOpen.Net Front Page
 
-A landing page for [http://peoplesopen.net/](peoplesopen.net).
+A landing page for [peoplesopen.net](http://peoplesopen.net/).
 
 Forked from [martini](https://github.com/codegangsta/martini) gh-pages branch.


### PR DESCRIPTION
The link got the Markdown syntax confused and swapped link and text.
