### PR TITLE
change home page description from disaster.radio to PON

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Welcome to the People's Open Network"
-description: 'disaster.radio is a disaster-resilient communications network powered by the sun.'
+description: 'People's Open is a community-owned-and-operated wireless network in Oakland, California.'
 layout: homepage
 html_title: "Welcome to the People's Open Network"
 _comment: 'Add/change content in the homepage template: /templates/layout/homepage.twig. Content below is ignored.'


### PR DESCRIPTION
Currently if you google for "peoples open network", you see a result with the disaster.radio description.

This will fix that.